### PR TITLE
Cambiado idioma en HTML a Español

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
 	<meta charset="utf-8" />
 	<title>INICIO | COORDICANARIAS</title>

--- a/frontend/sections/Igualdad.html
+++ b/frontend/sections/Igualdad.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
 	<meta charset="utf-8" />
 	<title>MUJER E IGUALDAD | COORDICANARIAS</title>

--- a/frontend/sections/empleo.html
+++ b/frontend/sections/empleo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
     <meta charset="utf-8" />
     <title>EMPLEO | COORDICANARIAS</title>

--- a/frontend/sections/formacion.html
+++ b/frontend/sections/formacion.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
   <meta charset="utf-8" />
   <title>FORMACIÓN | COORDICANARIAS</title>

--- a/frontend/sections/integral.html
+++ b/frontend/sections/integral.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
     <meta charset="utf-8" />
     <title>ATENCIÓN INTEGRAL | COORDICANARIAS</title>

--- a/frontend/sections/ocio.html
+++ b/frontend/sections/ocio.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
 	<meta charset="utf-8" />
 	<title>OCIO Y TIEMPO LIBRE| COORDICANARIAS</title>

--- a/frontend/sections/transparencia.html
+++ b/frontend/sections/transparencia.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
 <head>
 	<meta charset="utf-8" />
 	<title>TRANSPARENCIA | COORDICANARIAS</title>


### PR DESCRIPTION
En todas las versiones anteriores de la página, el documento se presentaba con el idioma en ingles, lo cual causaba que los navegadores en sistemas españoles (Ej. Ordenadores del Aula) preguntasen si el usuario quería traducir la página.

Este arreglo solamente cambia los documentos para que especifiquen el idioma correcto en el cual están escritos